### PR TITLE
Updated README.md and fixed uv sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,8 @@ For other implementations of Posit arithmetic, see the Implementations section i
 # Installation
 
 1. Clone this directory into your project folder.
-2. Activate your Python virtual environment.
-3. `cd` into this folder.
-4. Run `pip install -e ./cuPosit/`.
+2. `cd` into this folder.
+3. `uv sync`
 
 Now you can use cuposit in your environment. 
 
@@ -52,8 +51,9 @@ Install `uv`: https://docs.astral.sh/uv/getting-started/installation/#installati
 ```sh
 curl -LsSf https://astral.sh/uv/install.sh | sh
 uv python install 3.12
+uv pin python 3.12
 uv sync
-source .venv/bin/activate
+uv run <file>.py
 ```
 
 Then go into the examples folder and run any example you'd like.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,16 @@ cuposit = ["*.so", "*.pyd"]
 
 [tool.uv]
 package = true
+
+[tool.uv.workspace]
+members = [
+    ".",
+]
+
+[tool.uv.sources]
+cuposit = { workspace = true}
+
+[dependency-groups]
+dev = [
+    "cuposit",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -55,6 +55,11 @@ dependencies = [
     { name = "torchvision" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "cuposit" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "icecream", specifier = ">=2.1.8" },
@@ -63,6 +68,9 @@ requires-dist = [
     { name = "torch", specifier = ">=2.10.0" },
     { name = "torchvision", specifier = ">=0.25.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "cuposit", editable = "." }]
 
 [[package]]
 name = "executing"


### PR DESCRIPTION
I have modified pyproject.toml so that uv automatically handles the python version and package version conflicts.
I have also updated README.md for the same. Any doubts please contact me.

For installing custom kernels, I have used
```
uv add --editable --dev .
```
This automatically adds the custom kernel in pyproject.toml so that uv sync automatically installs them.
Moreover, uv run will automatically use the python from .venv which it has created. We don't need to source the environment.

Note: Verified for ubuntu os

Any doubts please ping me.